### PR TITLE
[feat] 리셀 주문 생성 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 ext {
-//    set('springCloudVersion', "2025.0.0")
+    set('springCloudVersion', "2025.0.0")
 }
 
 dependencies {
@@ -34,7 +34,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
@@ -53,7 +54,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-//        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 

--- a/src/main/java/com/limito/order/OrderApplication.java
+++ b/src/main/java/com/limito/order/OrderApplication.java
@@ -2,8 +2,10 @@ package com.limito.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OrderApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/limito/order/order/controller/OrderControllerV1.java
+++ b/src/main/java/com/limito/order/order/controller/OrderControllerV1.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
+import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
+import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
 import com.limito.order.order.service.OrderServiceV1;
 
 import jakarta.validation.Valid;
@@ -25,6 +27,15 @@ public class OrderControllerV1 {
 		// Todo. userId 헤더에서 빼오기, 권한검증
 		Long userId = 1111L;
 		CreateLimitedOrderResponseV1 result = orderService.createDirectLimitedOrder(userId, createLimitedOrderRequest);
+		return ResponseEntity.ok(result);
+	}
+
+	@PostMapping("/resell")
+	public ResponseEntity<CreateResellOrderResponseV1> createResellOrder(
+		@Valid @RequestBody CreateResellOrderRequestV1 createResellOrderRequest) {
+		// Todo. userId 헤더에서 빼오기, 권한검증
+		Long userId = 1111L;
+		CreateResellOrderResponseV1 result = orderService.createResellOrder(userId, createResellOrderRequest);
 		return ResponseEntity.ok(result);
 	}
 }

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderItemRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderItemRequestV1.java
@@ -17,7 +17,7 @@ public class CreateLimitedOrderItemRequestV1 {
 	private UUID optionId;
 
 	@NotNull(message = "아이템 아이디는 필수입니다.")
-	private UUID itemId;
+	private UUID productItemId;
 
 	@NotNull(message = "상품 타입은 필수입니다.")
 	private ProductType productType;

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderItemRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderItemRequestV1.java
@@ -8,10 +8,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CreateLimitedOrderItemRequestV1 {
 	@NotNull(message = "옵션 아이디는 필수입니다.")
 	private UUID optionId;

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateLimitedOrderRequestV1.java
@@ -8,10 +8,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CreateLimitedOrderRequestV1 {
 	@NotBlank(message = "수령인은 필수입니다.")
 	private String receiverName;
@@ -30,6 +28,7 @@ public class CreateLimitedOrderRequestV1 {
 	@Positive(message = "가격은 양수이어야 합니다.")
 	private Long totalPrice;
 
+	@NotNull(message = "주문 아이템은 필수입니다.")
 	@Size(min = 1, message = "주문 상품은 최소 1개 이상이어야 합니다.")
 	private List<CreateLimitedOrderItemRequestV1> items;
 }

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderItemRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderItemRequestV1.java
@@ -1,0 +1,46 @@
+package com.limito.order.order.domain.dto.request;
+
+import java.util.UUID;
+
+import com.limito.order.common.ProductType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateResellOrderItemRequestV1 {
+	@NotNull(message = "옵션 아이디는 필수입니다.")
+	private UUID optionId;
+
+	@NotNull(message = "재고 아이디는 필수입니다.")
+	private UUID stockId;
+
+	@NotNull(message = "상품 아이디는 필수입니다.")
+	private UUID productId;
+
+	@NotNull(message = "상품 타입은 필수입니다.")
+	private ProductType productType;
+
+	@NotBlank(message = "상품 이름은 필수입니다.")
+	private String productName;
+
+	@NotBlank(message = "브랜드명은 필수입니다.")
+	private String brandName;
+
+	@NotNull(message = "판매 업체 아이디는 필수입니다.")
+	private Long sellerId;
+
+	@NotBlank(message = "상품 색상은 필수입니다.")
+	private String productColor;
+
+	@NotBlank(message = "상품 사이즈는 필수입니다.")
+	private String productSize;
+
+	@NotBlank(message = "상품 가격은 필수입니다.")
+	@Positive(message = "가격은 양수이어야 합니다.")
+	private int productPrice;
+}

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderItemRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderItemRequestV1.java
@@ -8,10 +8,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CreateResellOrderItemRequestV1 {
 	@NotNull(message = "옵션 아이디는 필수입니다.")
 	private UUID optionId;

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
@@ -1,0 +1,35 @@
+package com.limito.order.order.domain.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateResellOrderRequestV1 {
+	@NotBlank(message = "수령인은 필수입니다.")
+	private String receiverName;
+
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@Pattern(
+		regexp = "^010-\\d{4}-\\d{4}$",
+		message = "전화번호 형식은 010-1234-5678 형태여야 합니다."
+	)
+	private String phoneNumber;
+
+	@NotBlank(message = "배송지 주소는 필수입니다.")
+	private String deliveryAddress;
+
+	@NotNull(message = "전체가격은 필수입니다.")
+	@Positive(message = "가격은 양수이어야 합니다.")
+	private Long totalPrice;
+
+	@Size(min = 1, message = "주문 상품은 최소 1개 이상이어야 합니다.")
+	private List<CreateLimitedOrderItemRequestV1> items;
+}

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
@@ -31,5 +31,5 @@ public class CreateResellOrderRequestV1 {
 	private Long totalPrice;
 
 	@Size(min = 1, message = "주문 상품은 최소 1개 이상이어야 합니다.")
-	private List<CreateLimitedOrderItemRequestV1> items;
+	private List<CreateResellOrderItemRequestV1> items;
 }

--- a/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/request/CreateResellOrderRequestV1.java
@@ -8,10 +8,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CreateResellOrderRequestV1 {
 	@NotBlank(message = "수령인은 필수입니다.")
 	private String receiverName;
@@ -30,6 +28,7 @@ public class CreateResellOrderRequestV1 {
 	@Positive(message = "가격은 양수이어야 합니다.")
 	private Long totalPrice;
 
+	@NotNull(message = "주문 아이템은 필수입니다.")
 	@Size(min = 1, message = "주문 상품은 최소 1개 이상이어야 합니다.")
 	private List<CreateResellOrderItemRequestV1> items;
 }

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderItemResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderItemResponseV1.java
@@ -15,7 +15,7 @@ public class CreateLimitedOrderItemResponseV1 {
 	private UUID orderItemId;
 
 	private UUID optionId;
-	private UUID itemId;
+	private UUID productItemId;
 
 	private ProductType productType;
 	private String productName;

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderItemResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderItemResponseV1.java
@@ -6,10 +6,8 @@ import com.limito.order.common.ProductType;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class CreateLimitedOrderItemResponseV1 {
 	private UUID orderItemId;

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateLimitedOrderResponseV1.java
@@ -8,10 +8,8 @@ import com.limito.order.common.OrderStatus;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class CreateLimitedOrderResponseV1 {
 	private UUID orderId;

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderItemResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderItemResponseV1.java
@@ -1,0 +1,30 @@
+package com.limito.order.order.domain.dto.response;
+
+import java.util.UUID;
+
+import com.limito.order.common.ProductType;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CreateResellOrderItemResponseV1 {
+	private UUID orderItemId;
+
+	private UUID optionId;
+	private UUID stockId;
+	private UUID productId;
+
+	private ProductType productType;
+	private String productName;
+	private String brandName;
+	private Long sellerId;
+
+	private String productColor;
+	private String productSize;
+
+	private int productPrice;
+}

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderItemResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderItemResponseV1.java
@@ -6,10 +6,8 @@ import com.limito.order.common.ProductType;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class CreateResellOrderItemResponseV1 {
 	private UUID orderItemId;

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
@@ -28,5 +28,5 @@ public class CreateResellOrderResponseV1 {
 	private String itemSummary;
 	// private String cancelReason;
 
-	private List<CreateLimitedOrderItemResponseV1> items;
+	private List<CreateResellOrderItemResponseV1> items;
 }

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
@@ -1,0 +1,32 @@
+package com.limito.order.order.domain.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.limito.order.common.OrderStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CreateResellOrderResponseV1 {
+	private UUID orderId;
+
+	private Long userId;
+	private String receiverName;
+	private String phoneNumber;
+	private String deliveryAddress;
+
+	private Long totalPrice;
+
+	private OrderStatus orderStatus;
+	private LocalDateTime successedAt;
+	private String itemSummary;
+	// private String cancelReason;
+
+	private List<CreateLimitedOrderItemResponseV1> items;
+}

--- a/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/CreateResellOrderResponseV1.java
@@ -8,10 +8,8 @@ import com.limito.order.common.OrderStatus;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class CreateResellOrderResponseV1 {
 	private UUID orderId;

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/ResellFeignClient.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/ResellFeignClient.java
@@ -1,0 +1,24 @@
+package com.limito.order.order.domain.feignClient.resell;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.limito.order.order.domain.feignClient.resell.dto.request.StockReduceRequest;
+
+import jakarta.validation.Valid;
+
+@FeignClient(name = "resell-product-service")
+public interface ResellFeignClient {
+	// 임시 재고 예약
+	@PostMapping("/internal/v1/resell-products/stock/reserve")
+	ResponseEntity<Object> reserveStock(List<UUID> stockIds);
+
+	// 재고 차감
+	@PostMapping("/internal/v1/resell-products/stock/reduce")
+	ResponseEntity<Object> reduceStock(@Valid @RequestBody List<StockReduceRequest> request);
+}

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/ResellFeignClient.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/ResellFeignClient.java
@@ -12,11 +12,11 @@ import com.limito.order.order.domain.feignClient.resell.dto.request.StockReduceR
 
 import jakarta.validation.Valid;
 
-@FeignClient(name = "resell-product-service")
+@FeignClient(name = "resell-product-service", url = "${feign.resell-product-service.url}")
 public interface ResellFeignClient {
 	// 임시 재고 예약
-	@PostMapping("/internal/v1/resell-products/stock/reserve")
-	ResponseEntity<Object> reserveStock(List<UUID> stockIds);
+	@PostMapping("internal/v1/resell-products/stock/reserve")
+	ResponseEntity<Object> reserveStock(@RequestBody List<UUID> stockIds);
 
 	// 재고 차감
 	@PostMapping("/internal/v1/resell-products/stock/reduce")

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
@@ -3,7 +3,9 @@ package com.limito.order.order.domain.feignClient.resell.dto.request;
 import java.util.UUID;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class StockReduceRequest {
 	@NotNull
 	private UUID productId;

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
@@ -1,0 +1,16 @@
+package com.limito.order.order.domain.feignClient.resell.dto.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+public class StockReduceRequest {
+	@NotNull
+	private UUID productId;
+
+	@NotNull
+	private UUID optionId;
+
+	@NotNull
+	private UUID stockId;
+}

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockReduceRequest.java
@@ -2,6 +2,8 @@ package com.limito.order.order.domain.feignClient.resell.dto.request;
 
 import java.util.UUID;
 
+import com.limito.order.order.domain.model.OrderItem;
+
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 
@@ -15,4 +17,11 @@ public class StockReduceRequest {
 
 	@NotNull
 	private UUID stockId;
+
+	public static StockReduceRequest createRequest(OrderItem orderItem) {
+		UUID productId = orderItem.getProductId();
+		UUID optionId = orderItem.getOptionId();
+		UUID stockId = orderItem.getStockId();
+		return new StockReduceRequest(productId, optionId, stockId);
+	}
 }

--- a/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockRollbackRequest.java
+++ b/src/main/java/com/limito/order/order/domain/feignClient/resell/dto/request/StockRollbackRequest.java
@@ -1,0 +1,17 @@
+package com.limito.order.order.domain.feignClient.resell.dto.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+public class StockRollbackRequest {
+
+	@NotNull
+	private UUID productId;
+
+	@NotNull
+	private UUID optionId;
+
+	@NotNull
+	private UUID stockId;
+}

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -33,7 +33,7 @@ public class OrderMapper {
 		req.getItems().forEach(itemReq -> {
 			OrderItem orderItem = OrderItem.builder()
 				.optionId(itemReq.getOptionId())
-				.itemId(itemReq.getItemId())
+				.productItemId(itemReq.getProductItemId())
 				.productType(itemReq.getProductType())
 				.productName(itemReq.getProductName())
 				.brandName(itemReq.getBrandName())
@@ -77,7 +77,7 @@ public class OrderMapper {
 			CreateLimitedOrderItemResponseV1 res = CreateLimitedOrderItemResponseV1.builder()
 				.orderItemId(orderItem.getId())
 				.optionId(orderItem.getOptionId())
-				.itemId(orderItem.getItemId())
+				.productItemId(orderItem.getProductItemId())
 				.productType(orderItem.getProductType())
 				.productName(orderItem.getProductName())
 				.brandName(orderItem.getBrandName())

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -7,8 +7,11 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
+import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderItemResponseV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
+import com.limito.order.order.domain.dto.response.CreateResellOrderItemResponseV1;
+import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
 import com.limito.order.order.domain.model.Order;
 import com.limito.order.order.domain.model.OrderItem;
 
@@ -16,6 +19,18 @@ import com.limito.order.order.domain.model.OrderItem;
 public class OrderMapper {
 
 	public Order toOrderEntity(Long userId, CreateLimitedOrderRequestV1 req) {
+		return Order.builder()
+			.userId(userId)
+			.receiverName(req.getReceiverName())
+			.phoneNumber(req.getPhoneNumber())
+			.deliveryAddress(req.getDeliveryAddress())
+			.totalPrice(req.getTotalPrice())
+			.orderStatus(com.limito.order.common.OrderStatus.ORDER_FINISH)
+			.successedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public Order toOrderEntity(Long userId, CreateResellOrderRequestV1 req) {
 		return Order.builder()
 			.userId(userId)
 			.receiverName(req.getReceiverName())
@@ -43,6 +58,29 @@ public class OrderMapper {
 				.productPrice(itemReq.getProductPrice())
 				.productAmount(itemReq.getProductAmount())
 				.totalProductPrice(itemReq.getTotalProductPrice())
+				.build();
+
+			orderItems.add(orderItem);
+		});
+
+		return orderItems;
+	}
+
+	public List<OrderItem> toOrderItemEntity(CreateResellOrderRequestV1 req) {
+		List<OrderItem> orderItems = new ArrayList<>();
+
+		req.getItems().forEach(itemReq -> {
+			OrderItem orderItem = OrderItem.builder()
+				.optionId(itemReq.getOptionId())
+				.stockId(itemReq.getStockId())
+				.productId(itemReq.getProductId())
+				.productType(itemReq.getProductType())
+				.productName(itemReq.getProductName())
+				.brandName(itemReq.getBrandName())
+				.sellerId(itemReq.getSellerId())
+				.productColor(itemReq.getProductColor())
+				.productSize(itemReq.getProductSize())
+				.productPrice(itemReq.getProductPrice())
 				.build();
 
 			orderItems.add(orderItem);
@@ -87,6 +125,48 @@ public class OrderMapper {
 				.productPrice(orderItem.getProductPrice())
 				.productAmount(orderItem.getProductAmount())
 				.totalProductPrice(orderItem.getTotalProductPrice())
+				.build();
+
+			responses.add(res);
+		});
+
+		return responses;
+	}
+
+	public CreateResellOrderResponseV1 toResellOrderResponse(Order order) {
+		List<CreateResellOrderItemResponseV1> resellOrderItemResponses = toResellOrderItemResponse(order);
+
+		return CreateResellOrderResponseV1.builder()
+			.orderId(order.getId())
+			.userId(order.getUserId())
+			.receiverName(order.getReceiverName())
+			.phoneNumber(order.getPhoneNumber())
+			.deliveryAddress(order.getDeliveryAddress())
+			.totalPrice(order.getTotalPrice())
+			.orderStatus(order.getOrderStatus())
+			.successedAt(order.getSuccessedAt())
+			.itemSummary(order.getItemSummary())
+			.items(resellOrderItemResponses)
+			.build();
+	}
+
+	public List<CreateResellOrderItemResponseV1> toResellOrderItemResponse(Order order) {
+		List<OrderItem> orderItems = order.getOrderItems();
+		List<CreateResellOrderItemResponseV1> responses = new ArrayList<>();
+
+		orderItems.forEach(orderItem -> {
+			CreateResellOrderItemResponseV1 res = CreateResellOrderItemResponseV1.builder()
+				.orderItemId(orderItem.getId())
+				.optionId(orderItem.getOptionId())
+				.stockId(orderItem.getStockId())
+				.productId(orderItem.getProductId())
+				.productType(orderItem.getProductType())
+				.productName(orderItem.getProductName())
+				.brandName(orderItem.getBrandName())
+				.sellerId(orderItem.getSellerId())
+				.productColor(orderItem.getProductColor())
+				.productSize(orderItem.getProductSize())
+				.productPrice(orderItem.getProductPrice())
 				.build();
 
 			responses.add(res);

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.limito.order.common.OrderStatus;
 import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
 import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderItemResponseV1;
@@ -37,7 +38,7 @@ public class OrderMapper {
 			.phoneNumber(req.getPhoneNumber())
 			.deliveryAddress(req.getDeliveryAddress())
 			.totalPrice(req.getTotalPrice())
-			.orderStatus(com.limito.order.common.OrderStatus.ORDER_FINISH)
+			.orderStatus(OrderStatus.ORDER_FINISH)
 			.successedAt(LocalDateTime.now())
 			.build();
 	}

--- a/src/main/java/com/limito/order/order/domain/model/Order.java
+++ b/src/main/java/com/limito/order/order/domain/model/Order.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import com.limito.order.common.OrderStatus;
 import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
+import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -78,6 +79,15 @@ public class Order {
 		int itemCount = req.getItems().size() - 1;
 		String firstProductName = req.getItems().get(0).getProductName();
 		this.itemSummary = firstProductName + " 외 " + itemCount + "건";
+	}
+
+	public void attachSummary(CreateResellOrderRequestV1 req) {
+		int itemCount = req.getItems().size() - 1;
+		String firstProductName = req.getItems().get(0).getProductName();
+		this.itemSummary = firstProductName + " 외 " + itemCount + "건";
+		if (itemCount == 0) {
+			this.itemSummary = firstProductName;
+		}
 	}
 
 	public List<OrderItem> deliverOrderItems(Order order) {

--- a/src/main/java/com/limito/order/order/domain/model/Order.java
+++ b/src/main/java/com/limito/order/order/domain/model/Order.java
@@ -93,4 +93,13 @@ public class Order {
 	public List<OrderItem> deliverOrderItems(Order order) {
 		return order.getOrderItems();
 	}
+
+	public static List<UUID> getStockIds(Order order) {
+		List<OrderItem> orderItems = order.getOrderItems();
+		List<UUID> stockIds = new ArrayList<>();
+		orderItems.forEach(orderItem -> {
+			stockIds.add(orderItem.getStockId());
+		});
+		return stockIds;
+	}
 }

--- a/src/main/java/com/limito/order/order/domain/model/OrderItem.java
+++ b/src/main/java/com/limito/order/order/domain/model/OrderItem.java
@@ -39,10 +39,13 @@ public class OrderItem {
 	private UUID optionId;
 
 	@Column(name = "product_item_id")
-	private UUID itemId;
+	private UUID productItemId;
 
 	@Column(name = "product_stock_id")
 	private UUID stockId;
+
+	@Column(name = "product_id")
+	private UUID productId;
 
 	@Column(name = "product_type", nullable = false)
 	private ProductType productType;

--- a/src/main/java/com/limito/order/order/domain/model/OrderItem.java
+++ b/src/main/java/com/limito/order/order/domain/model/OrderItem.java
@@ -71,7 +71,7 @@ public class OrderItem {
 	@Column(name = "product_amount", nullable = false)
 	private int productAmount;
 
-	@Column(name = "total_product_price", nullable = false)
+	@Column(name = "total_product_price")
 	private Long totalProductPrice;
 
 	public void attachOrder(Order order) {

--- a/src/main/java/com/limito/order/order/service/OrderServiceV1.java
+++ b/src/main/java/com/limito/order/order/service/OrderServiceV1.java
@@ -84,7 +84,7 @@ public class OrderServiceV1 {
 
 		// 상품 feign : 임시 재고 예약
 		// Todo. 예외처리
-		List<UUID> stockIds = getStockIds(orderItems);
+		List<UUID> stockIds = Order.getStockIds(order);
 		resellFeignClient.reserveStock(stockIds);
 
 		// 상품 feign: 재고 차감 요청
@@ -101,18 +101,9 @@ public class OrderServiceV1 {
 	private List<StockReduceRequest> createStockReduceRequests(List<OrderItem> orderItems) {
 		List<StockReduceRequest> requests = new ArrayList<>();
 		orderItems.forEach(orderItem -> {
-			StockReduceRequest req = new StockReduceRequest(orderItem.getProductId(), orderItem.getOptionId(),
-				orderItem.getStockId());
+			StockReduceRequest req = StockReduceRequest.createRequest(orderItem);
 			requests.add(req);
 		});
 		return requests;
-	}
-
-	private List<UUID> getStockIds(List<OrderItem> orderItems) {
-		List<UUID> stockIds = new ArrayList<>();
-		orderItems.forEach(orderItem -> {
-			stockIds.add(orderItem.getStockId());
-		});
-		return stockIds;
 	}
 }

--- a/src/main/java/com/limito/order/order/service/OrderServiceV1.java
+++ b/src/main/java/com/limito/order/order/service/OrderServiceV1.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
+import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
+import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
 import com.limito.order.order.domain.mapper.OrderMapper;
 import com.limito.order.order.domain.model.Order;
 import com.limito.order.order.domain.model.OrderItem;
@@ -55,21 +57,32 @@ public class OrderServiceV1 {
 		return limitedOrderRes;
 	}
 
-	// // requestDto -> entity 변환 메서드
-	// private Order createLimitedOrder(Long userId,
-	// 	CreateLimitedOrderRequestV1 createLimitedOrderRequest) {
-	// 	// requestDto -> entity 매핑해서 주문 엔티티 생성
-	// 	Order order = orderMapper.toOrderEntity(userId, createLimitedOrderRequest);
-	//
-	// 	// requestDto -> entity 매핑해서 주문 아이템 엔티티 생성 후 orderItems로 반환
-	// 	List<OrderItem> orderItems = orderMapper.toOrderItemEntity(createLimitedOrderRequest);
-	// 	// 연관관계 설정
-	// 	order.attachOrderItems(orderItems);
-	//
-	// 	// itemSummary set 하는 함수 추가하기
-	// 	order.attachSummary(createLimitedOrderRequest);
-	//
-	// 	// 생성된 주문 엔티티 저장
-	// 	return orderRepository.save(order);
-	// }
+	// 리셀 주문 생성
+	@Transactional
+	public CreateResellOrderResponseV1 createResellOrder(Long userId,
+		CreateResellOrderRequestV1 createResellOrderRequest) {
+
+		// Todo. 합산 가격 검증 (더블 체크)
+
+		Order order = orderMapper.toOrderEntity(userId, createResellOrderRequest);
+		List<OrderItem> orderItems = orderMapper.toOrderItemEntity(createResellOrderRequest);
+		order.attachOrderItems(orderItems);
+
+		order.attachSummary(createResellOrderRequest);
+
+		orderRepository.save(order);
+
+		/** Todo :
+		 * 1. 상품 feign : 임시 재고 예약 (최대 구매 가능 수량 포함)
+		 * 2. 결제 feign : 결제 요청
+		 * 3. 상품 feign: 재고 차감 요청
+		 * 4. 주문 상품 장바구니에서 차감
+		 */
+
+		// 엔티티 -> responseDto 변환해서 리턴
+		//		List<CreateLimitedOrderItemResponseV1> orderItemRes = orderMapper.toLimitedOrderItemResponse(order);
+		CreateResellOrderResponseV1 rsellOrderRes = orderMapper.toResellOrderResponse(order);
+
+		return rsellOrderRes;
+	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,16 @@ spring:
     password: postgres
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+eureka:
+  client:
+    service-url:
+      default-zone: http://localhost:19090/eureka
+
+feign:
+  resell-product-service:
+    url: http://localhost:19095


### PR DESCRIPTION
#이슈번호
#28 

### 변경사항
- 리셀 주문 생성
    - 바로 주문, 장바구니 주문 구분하지 않고 하나로 통합 
    - 단일, 다중 모두 가능 
- 리셀 feign client 연동
    - 리셀 도메인 테스트 데이터 없어서 연동 테스트 제외함

### 리뷰요청
- 서비스단에서 getter 사용하지 않도록 한 리팩토링이 적절한지
- feign client 연동부는 추후 수정 가능성이 있으니 감안하고 봐주세요