### PR TITLE
[feat] Company 사용자가 자신의 상품에 대한 주문 내역 목록을 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/limito/order/order/controller/OrderControllerV1.java
+++ b/src/main/java/com/limito/order/order/controller/OrderControllerV1.java
@@ -1,8 +1,12 @@
 package com.limito.order.order.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,6 +14,7 @@ import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
 import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
 import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
+import com.limito.order.order.domain.dto.response.GetOrdersForCompanyResponseV1;
 import com.limito.order.order.service.OrderServiceV1;
 
 import jakarta.validation.Valid;
@@ -37,5 +42,16 @@ public class OrderControllerV1 {
 		Long userId = 1111L;
 		CreateResellOrderResponseV1 result = orderService.createResellOrder(userId, createResellOrderRequest);
 		return ResponseEntity.ok(result);
+	}
+
+	@GetMapping("/company")
+	public ResponseEntity<Slice<GetOrdersForCompanyResponseV1>> getOrdersForCompany(
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader("X-User-Role") String userRole,
+		Pageable pageable
+	) {
+		Slice<GetOrdersForCompanyResponseV1> response = orderService.getOrdersForCompany(userId, userRole, pageable);
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
@@ -4,8 +4,10 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class GetOrdersForCompanyResponseV1 {
 	private UUID orderId;
 	private String itemSummary;

--- a/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class GetOrdersForCompanyResponseV1 {
+
 	private UUID orderId;
 	private String itemSummary;
 	private Long totalPrice;

--- a/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
@@ -13,5 +13,5 @@ public class GetOrdersForCompanyResponseV1 {
 	private UUID orderId;
 	private String itemSummary;
 	private Long totalPrice;
-	private LocalDateTime successAt;
+	private LocalDateTime successedAt;
 }

--- a/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
@@ -1,0 +1,15 @@
+package com.limito.order.order.domain.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record GetOrdersForCompanyResponseV1(
+	UUID orderId,
+	String itemSummary,
+	Long totalPrice,
+	LocalDateTime successAt
+) {
+}

--- a/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
+++ b/src/main/java/com/limito/order/order/domain/dto/response/GetOrdersForCompanyResponseV1.java
@@ -6,10 +6,9 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record GetOrdersForCompanyResponseV1(
-	UUID orderId,
-	String itemSummary,
-	Long totalPrice,
-	LocalDateTime successAt
-) {
+public class GetOrdersForCompanyResponseV1 {
+	private UUID orderId;
+	private String itemSummary;
+	private Long totalPrice;
+	private LocalDateTime successAt;
 }

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -183,7 +183,7 @@ public class OrderMapper {
 			.orderId(companyOrder.getOrderId())
 			.itemSummary(companyOrder.getItemSummary())
 			.totalPrice(companyOrder.getTotalPrice())
-			.successAt(companyOrder.getSuccessAt())
+			.successedAt(companyOrder.getSuccessAt())
 			.build();
 	}
 }

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -13,6 +13,8 @@ import com.limito.order.order.domain.dto.response.CreateLimitedOrderItemResponse
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
 import com.limito.order.order.domain.dto.response.CreateResellOrderItemResponseV1;
 import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
+import com.limito.order.order.domain.dto.response.GetOrdersForCompanyResponseV1;
+import com.limito.order.order.domain.model.CompanyOrder;
 import com.limito.order.order.domain.model.Order;
 import com.limito.order.order.domain.model.OrderItem;
 
@@ -176,4 +178,12 @@ public class OrderMapper {
 		return responses;
 	}
 
+	public GetOrdersForCompanyResponseV1 toGetOrdersForCompanyResponse(CompanyOrder companyOrder) {
+		return GetOrdersForCompanyResponseV1.builder()
+			.orderId(companyOrder.getOrderId())
+			.itemSummary(companyOrder.getItemSummary())
+			.totalPrice(companyOrder.getTotalPrice())
+			.successAt(companyOrder.getSuccessAt())
+			.build();
+	}
 }

--- a/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
+++ b/src/main/java/com/limito/order/order/domain/mapper/OrderMapper.java
@@ -183,7 +183,7 @@ public class OrderMapper {
 			.orderId(companyOrder.getOrderId())
 			.itemSummary(companyOrder.getItemSummary())
 			.totalPrice(companyOrder.getTotalPrice())
-			.successAt(companyOrder.getSuccessAt())
+			.successedAt(companyOrder.getSuccessedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/limito/order/order/domain/model/CompanyOrder.java
+++ b/src/main/java/com/limito/order/order/domain/model/CompanyOrder.java
@@ -15,12 +15,12 @@ public class CompanyOrder {
 	UUID orderId;
 	String itemSummary;
 	Long totalPrice;
-	LocalDateTime successAt;
+	LocalDateTime successedAt;
 
-	public CompanyOrder(UUID orderId, String itemSummary, Long totalPrice, LocalDateTime successAt) {
+	public CompanyOrder(UUID orderId, String itemSummary, Long totalPrice, LocalDateTime successedAt) {
 		this.orderId = orderId;
 		this.itemSummary = itemSummary;
 		this.totalPrice = totalPrice;
-		this.successAt = successAt;
+		this.successedAt = successedAt;
 	}
 }

--- a/src/main/java/com/limito/order/order/domain/model/CompanyOrder.java
+++ b/src/main/java/com/limito/order/order/domain/model/CompanyOrder.java
@@ -1,0 +1,26 @@
+package com.limito.order.order.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@EqualsAndHashCode
+public class CompanyOrder {
+
+	UUID orderId;
+	String itemSummary;
+	Long totalPrice;
+	LocalDateTime successAt;
+
+	public CompanyOrder(UUID orderId, String itemSummary, Long totalPrice, LocalDateTime successAt) {
+		this.orderId = orderId;
+		this.itemSummary = itemSummary;
+		this.totalPrice = totalPrice;
+		this.successAt = successAt;
+	}
+}

--- a/src/main/java/com/limito/order/order/domain/model/OrderItem.java
+++ b/src/main/java/com/limito/order/order/domain/model/OrderItem.java
@@ -6,6 +6,8 @@ import com.limito.order.common.ProductType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -48,6 +50,7 @@ public class OrderItem {
 	private UUID productId;
 
 	@Column(name = "product_type", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private ProductType productType;
 
 	@Column(name = "product_name", nullable = false, length = 100)

--- a/src/main/java/com/limito/order/order/domain/repository/OrderRepositoryV1.java
+++ b/src/main/java/com/limito/order/order/domain/repository/OrderRepositoryV1.java
@@ -2,10 +2,33 @@ package com.limito.order.order.domain.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import com.limito.order.common.OrderStatus;
+import com.limito.order.order.domain.model.CompanyOrder;
 import com.limito.order.order.domain.model.Order;
 
 public interface OrderRepositoryV1 extends JpaRepository<Order, UUID> {
 
+	@Query("""
+			SELECT new com.limito.order.order.domain.model.CompanyOrder(
+				o.id,
+				o.itemSummary,
+				o.totalPrice,
+				o.successedAt
+			)
+			FROM Order o
+			WHERE o.orderStatus <> :orderStatus
+				AND EXISTS (
+					SELECT 1
+					FROM OrderItem i
+					WHERE i.order = o
+						AND i.sellerId = :userId
+				)
+			ORDER BY o.successedAt DESC
+		""")
+	Slice<CompanyOrder> findAllBySellerIdAndOrderStatusNot(Long userId, OrderStatus orderStatus, Pageable pageable);
 }

--- a/src/main/java/com/limito/order/order/service/OrderServiceV1.java
+++ b/src/main/java/com/limito/order/order/service/OrderServiceV1.java
@@ -1,9 +1,12 @@
 package com.limito.order.order.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -22,7 +25,9 @@ import com.limito.order.order.domain.dto.request.CreateLimitedOrderRequestV1;
 import com.limito.order.order.domain.dto.request.CreateResellOrderRequestV1;
 import com.limito.order.order.domain.dto.response.CreateLimitedOrderResponseV1;
 import com.limito.order.order.domain.dto.response.CreateResellOrderResponseV1;
+import com.limito.order.order.domain.dto.response.GetOrdersForCompanyResponseV1;
 import com.limito.order.order.domain.mapper.OrderMapper;
+import com.limito.order.order.domain.model.CompanyOrder;
 import com.limito.order.order.domain.model.Order;
 import com.limito.order.order.domain.model.OrderItem;
 import com.limito.order.order.domain.repository.OrderRepositoryV1;
@@ -158,10 +163,28 @@ public class OrderServiceV1 {
 		return requests;
 	}
 
+	public Slice<GetOrdersForCompanyResponseV1> getOrdersForCompany(Long userId, String userRole, Pageable pageable) {
+		validateRole(userRole, "COMPANY");
+
+		Slice<CompanyOrder> companyOrders =
+			orderRepository.findAllBySellerIdAndOrderStatusNot(userId, OrderStatus.ORDER_PENDING, pageable);
+
+		return companyOrders.map(orderMapper::toGetOrdersForCompanyResponse);
+	}
+
 	private void validateReserveFeign(ResponseEntity<Void> reserveFeignResponse) {
 		if (!HttpStatus.OK.equals(reserveFeignResponse.getStatusCode())) {
 			throw AppException.of(HttpStatus.EXPECTATION_FAILED, "임시 재고 예약에 실패했습니다");
 			// Todo : 예외처리 강화 - feign 응답에 맞춰서
+		}
+	}
+
+	private void validateRole(String userRole, String... roles) {
+		if (
+			!Arrays.asList(roles)
+				.contains(userRole)
+		) {
+			throw AppException.of(HttpStatus.FORBIDDEN, "조회 권한이 없습니다.");
 		}
 	}
 }

--- a/src/main/resources/http/주문_목록_조회.http
+++ b/src/main/resources/http/주문_목록_조회.http
@@ -1,0 +1,3 @@
+GET http://localhost:19096/api/v1/orders/company?page=0&size=10
+X-User-Id: 1001
+X-User-Role: COMPANY


### PR DESCRIPTION
[정책]
- 주문 대기 중인 상품은 보여주지 않는다.
- 주문 성공 시간을 기준으로 내림차순 정렬을 한다.

[변경 사항]
User role과 Company role의 주문 내역 목록 조회를 별도의 api로 분리했습니다.
이유: User role은 주문 테이블의 user_id 컬럼으로 조회가 가능하지만, Company role은 주문 아이템의 seller_id를 통해 조회하므로 내부 로직이 완전히 다름.