### PR TITLE
[fix] 장바구니로 주문한 아이템 장바구니 삭제 기능 api로 분리

### DIFF
--- a/src/main/java/com/limito/order/cart/controller/CartControllerV1.java
+++ b/src/main/java/com/limito/order/cart/controller/CartControllerV1.java
@@ -1,8 +1,10 @@
 package com.limito.order.cart.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,7 +49,7 @@ public class CartControllerV1 {
 	}
 
 	// 한정판매 장바구니 조회
-	@GetMapping("limited")
+	@GetMapping("/limited")
 	public ResponseEntity<List<GetCartLimitedResponseV1>> getLimitedCart() {
 		// Todo. userId 헤더에서 추출, 권한 검증
 		Long userId = 1111L;
@@ -56,11 +58,29 @@ public class CartControllerV1 {
 	}
 
 	// 리셀 장바구니 조회
-	@GetMapping("resell")
+	@GetMapping("/resell")
 	public ResponseEntity<List<GetCartResellResponseV1>> getResellCart() {
 		// Todo. userId 헤더에서 추출, 권한 검증
 		Long userId = 1111L;
 		List<GetCartResellResponseV1> results = cartService.getResellCart(userId);
 		return ResponseEntity.ok(results);
+	}
+
+	// 한정판매 장바구니 주문 완료 아이템 삭제
+	@DeleteMapping("/limited-ordered")
+	public ResponseEntity<Void> deleteLimitedOrderItem(@Valid @RequestBody List<UUID> productItemIds) {
+		// Todo. userId 헤더에서 추출, 권한 검증
+		Long userId = 1111L;
+		cartService.deleteLimitedOrderItem(userId, productItemIds);
+		return ResponseEntity.ok(null);
+	}
+
+	// 리셀 장바구니 주문 완료 아이템 삭제
+	@DeleteMapping("/resell-ordered")
+	public ResponseEntity<Void> deleteResellOrderItem(@Valid @RequestBody List<UUID> optionIds) {
+		// Todo. userId 헤더에서 추출, 권한 검증
+		Long userId = 1111L;
+		cartService.deleteResellOrderItem(userId, optionIds);
+		return ResponseEntity.ok(null);
 	}
 }

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -120,6 +120,7 @@ public class CartServiceV1 {
 		return CartMapper.toAddResponse(saved);
 	}
 
+	// 한정판매 장바구니 조회
 	public List<GetCartLimitedResponseV1> getLimitedCart(Long userId) {
 		String key = LIMITED_KEY.formatted(userId);
 		HashOperations<String, String, Object> hashOps = hashOps();
@@ -135,6 +136,7 @@ public class CartServiceV1 {
 
 	}
 
+	// 리셀 장바구니 조회
 	public List<GetCartResellResponseV1> getResellCart(Long userId) {
 		String key = RESELL_KEY.formatted(userId);
 		HashOperations<String, String, Object> hashOps = hashOps();
@@ -174,20 +176,12 @@ public class CartServiceV1 {
 		HashOperations<String, String, Object> hashOps = hashOps();
 
 		// Redis에 실제로 존재하는 field만 모으기 (바로구매는 장바구니 거치지 않음)
-		List<String> existingFields = ids.stream()
+		List<String> idsToString = ids.stream()
 			.map(UUID::toString)
-			.filter(field -> Boolean.TRUE.equals(hashOps.hasKey(key, field)))
 			.toList();
 
-		// 장바구니에는 하나도 없을 수도 있음 (예: 장바구니 거치지 않고 바로 주문한 경우)
-		if (existingFields.isEmpty()) {
-			log.info("삭제할 장바구니 아이템이 없습니다.");
-			return;
-		}
-
-		// 존재하는 field들만 삭제
 		// HDEL cart:limited:{userId} field1 field2 ...
-		hashOps.delete(key, existingFields.toArray(new Object[0]));
+		// hashOps.delete(key, idsToString.toArray(new Object[0]));
 		log.info("주문 완료된 장바구니 아이템 삭제 완료");
 	}
 

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -183,7 +183,7 @@ public class CartServiceV1 {
 		Long deletedCount = hashOps.delete(key, (Object[])fields);
 		log.info("주문 완료된 장바구니 아이템 삭제 완료");
 
-		if (deletedCount == 0L) {
+		if (!deletedCount.equals((long)ids.size())) {
 			throw AppException.of(HttpStatus.EXPECTATION_FAILED, "주문 완료 아이템 장바구니에서 삭제하기에 실패했습니다.");
 		}
 

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -168,21 +168,25 @@ public class CartServiceV1 {
 			throw AppException.of(HttpStatus.NO_CONTENT, "장바구니에서 삭제할 상품 아이디가 존재하지 않습니다.");
 		}
 
-		String key = LIMITED_KEY.formatted(userId);
+		String key = RESELL_KEY.formatted(userId);
 		deleteOrderItems(key, optionIds);
 	}
 
 	private void deleteOrderItems(String key, List<UUID> ids) {
 		HashOperations<String, String, Object> hashOps = hashOps();
 
-		// Redis에 실제로 존재하는 field만 모으기 (바로구매는 장바구니 거치지 않음)
-		List<String> idsToString = ids.stream()
+		String[] fields = ids.stream()
 			.map(UUID::toString)
-			.toList();
+			.toArray(String[]::new);
 
 		// HDEL cart:limited:{userId} field1 field2 ...
-		// hashOps.delete(key, idsToString.toArray(new Object[0]));
+		Long deletedCount = hashOps.delete(key, (Object[])fields);
 		log.info("주문 완료된 장바구니 아이템 삭제 완료");
+
+		if (deletedCount == 0L) {
+			throw AppException.of(HttpStatus.EXPECTATION_FAILED, "주문 완료 아이템 장바구니에서 삭제하기에 실패했습니다.");
+		}
+
 	}
 
 	private ResponseEntity<GetPurchaseAmountLimitResponseV1> getFeignResponse(

--- a/src/main/java/com/limito/order/order/service/OrderInternalServiceV1.java
+++ b/src/main/java/com/limito/order/order/service/OrderInternalServiceV1.java
@@ -69,7 +69,7 @@ public class OrderInternalServiceV1 {
 			.filter(Objects::nonNull)
 			.toList();
 
-		cartService.deleteResellOrderItem(order.getUserId(), productItemIds);
+		//cartService.deleteLimitedOrderItem(order.getUserId(), productItemIds);
 	}
 
 	// 리셀 주문 완료
@@ -98,7 +98,7 @@ public class OrderInternalServiceV1 {
 			.filter(Objects::nonNull)
 			.toList();
 
-		cartService.deleteResellOrderItem(order.getUserId(), optionIds);
+		//cartService.deleteResellOrderItem(order.getUserId(), optionIds);
 	}
 
 	private List<StockReduceRequest> createStockReduceRequests(List<OrderItem> orderItems) {


### PR DESCRIPTION
#51 

### 변경사항
- 주문 완료 로직 내에서 삭제 -> api로 분리
- 삭제 상품의 아이디 리스트의 크기와 삭제 횟수가 같지 않으면 예외 던짐

### 리뷰요청
- 기능이 잘 동작 되는지
- 예외처리 기준과 예외가 적절한지