### PR TITLE
[fix] 장바구니 추가, 조회 및 캐싱 로직 변경

### DIFF
--- a/src/main/java/com/limito/order/cart/controller/CartControllerV1.java
+++ b/src/main/java/com/limito/order/cart/controller/CartControllerV1.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.limito.common.security.audit.UserRole;
+import com.limito.common.security.auth.CurrentUser;
+import com.limito.common.security.auth.PreAuthorized;
+import com.limito.common.security.context.UserContext;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedRequestV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.GetCartLimitedResponseV1;
@@ -29,58 +33,56 @@ public class CartControllerV1 {
 	private final CartServiceV1 cartService;
 
 	// 한정판매 장바구니 추가
+	@PreAuthorized({UserRole.USER})
 	@PostMapping("/limited")
 	public ResponseEntity<AddCartLimitedResponseV1> addLimitedItem(
+		@CurrentUser UserContext user,
 		@Valid @RequestBody AddCartLimitedRequestV1 addLimitedProductReqDto) {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		AddCartLimitedResponseV1 result = cartService.addLimitedItem(userId, addLimitedProductReqDto);
+		AddCartLimitedResponseV1 result = cartService.addLimitedItem(user, addLimitedProductReqDto);
 		return ResponseEntity.ok(result);
 	}
 
 	// 리셀 장바구니 추가
+	@PreAuthorized({UserRole.USER})
 	@PostMapping("/resell")
 	public ResponseEntity<AddCartResellResponseV1> addResellItem(
+		@CurrentUser UserContext user,
 		@Valid @RequestBody AddCartResellRequestV1 addResellProductReqDto) {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		AddCartResellResponseV1 result = cartService.addResellItem(userId, addResellProductReqDto);
+		AddCartResellResponseV1 result = cartService.addResellItem(user, addResellProductReqDto);
 		return ResponseEntity.ok(result);
 	}
 
 	// 한정판매 장바구니 조회
+	@PreAuthorized({UserRole.USER})
 	@GetMapping("/limited")
-	public ResponseEntity<List<GetCartLimitedResponseV1>> getLimitedCart() {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		List<GetCartLimitedResponseV1> results = cartService.getLimitedCart(userId);
+	public ResponseEntity<List<GetCartLimitedResponseV1>> getLimitedCart(@CurrentUser UserContext user) {
+		List<GetCartLimitedResponseV1> results = cartService.getLimitedCart(user);
 		return ResponseEntity.ok(results);
 	}
 
 	// 리셀 장바구니 조회
 	@GetMapping("/resell")
-	public ResponseEntity<List<GetCartResellResponseV1>> getResellCart() {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		List<GetCartResellResponseV1> results = cartService.getResellCart(userId);
+	@PreAuthorized({UserRole.USER})
+	public ResponseEntity<List<GetCartResellResponseV1>> getResellCart(@CurrentUser UserContext user) {
+		List<GetCartResellResponseV1> results = cartService.getResellCart(user);
 		return ResponseEntity.ok(results);
 	}
 
 	// 한정판매 장바구니 주문 완료 아이템 삭제
 	@DeleteMapping("/limited-ordered")
-	public ResponseEntity<Void> deleteLimitedOrderItem(@Valid @RequestBody List<UUID> productItemIds) {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		cartService.deleteLimitedOrderItem(userId, productItemIds);
+	public ResponseEntity<Void> deleteLimitedOrderItem(
+		@CurrentUser UserContext user,
+		@Valid @RequestBody List<UUID> productItemIds) {
+		cartService.deleteLimitedOrderItem(user, productItemIds);
 		return ResponseEntity.ok(null);
 	}
 
 	// 리셀 장바구니 주문 완료 아이템 삭제
 	@DeleteMapping("/resell-ordered")
-	public ResponseEntity<Void> deleteResellOrderItem(@Valid @RequestBody List<UUID> optionIds) {
-		// Todo. userId 헤더에서 추출, 권한 검증
-		Long userId = 1111L;
-		cartService.deleteResellOrderItem(userId, optionIds);
+	public ResponseEntity<Void> deleteResellOrderItem(
+		@CurrentUser UserContext user,
+		@Valid @RequestBody List<UUID> optionIds) {
+		cartService.deleteResellOrderItem(user, optionIds);
 		return ResponseEntity.ok(null);
 	}
 }

--- a/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetInCartProductInfoResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetInCartProductInfoResponseV1.java
@@ -1,0 +1,18 @@
+package com.limito.order.cart.domain.dto.feignclient.limited;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetInCartProductInfoResponseV1 {
+	private String productName;
+	private String productColor;
+	private String productSize;
+	private int productPrice;
+	private String brandName;
+	private String thumbnailUrl;
+	private Long sellerId;
+	private String productStatus;
+	private Boolean isSoldOut;
+}

--- a/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetPurchaseAmountLimitRequestV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetPurchaseAmountLimitRequestV1.java
@@ -1,4 +1,4 @@
-package com.limito.order.cart.domain.dto.feignclient;
+package com.limito.order.cart.domain.dto.feignclient.limited;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetPurchaseAmountLimitResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/feignclient/limited/GetPurchaseAmountLimitResponseV1.java
@@ -1,4 +1,4 @@
-package com.limito.order.cart.domain.dto.feignclient;
+package com.limito.order.cart.domain.dto.feignclient.limited;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/limito/order/cart/domain/dto/feignclient/resell/OptionInfosGetResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/feignclient/resell/OptionInfosGetResponseV1.java
@@ -1,0 +1,19 @@
+package com.limito.order.cart.domain.dto.feignclient.resell;
+
+import com.limito.order.common.ProductType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OptionInfosGetResponseV1 {
+	private String productName;
+	private String productColor;
+	private String productSize;
+	private int productPrice;
+	private String brandName;
+	private String thumbnailUrl;
+	private Long sellerId;
+	private ProductType productType;
+}

--- a/src/main/java/com/limito/order/cart/domain/dto/feignclient/resell/OptionInfosGetResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/feignclient/resell/OptionInfosGetResponseV1.java
@@ -1,5 +1,7 @@
 package com.limito.order.cart.domain.dto.feignclient.resell;
 
+import java.util.UUID;
+
 import com.limito.order.common.ProductType;
 
 import lombok.Builder;
@@ -8,6 +10,9 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OptionInfosGetResponseV1 {
+	private UUID optionId;
+	private UUID stockId;
+	private UUID productId;
 	private String productName;
 	private String productColor;
 	private String productSize;

--- a/src/main/java/com/limito/order/cart/domain/dto/limitedproduct/AddCartLimitedRequestV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/limitedproduct/AddCartLimitedRequestV1.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import com.limito.order.common.ProductType;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -18,31 +17,6 @@ public class AddCartLimitedRequestV1 {
 
 	@NotNull(message = "판매 아이템 아이디는 필수입니다.")
 	private UUID productItemId;
-
-	@NotBlank(message = "상품 이름은 필수입니다.")
-	private String productName;
-
-	@NotBlank(message = "상품 색상은 필수입니다.")
-	private String productColor;
-
-	@NotBlank(message = "상품 사이즈는 필수입니다.")
-	private String productSize;
-
-	@NotNull(message = "상품 가격은 필수입니다.")
-	@Positive
-	private int productPrice;
-
-	@NotBlank(message = "브랜드명은 필수입니다.")
-	private String brandName;
-
-	@NotBlank(message = "대표 이미지 url은 필수입니다.")
-	private String thumbnailUrl;
-
-	@NotNull(message = "판매 업체 아이디는 필수입니다.")
-	private Long sellerId;
-
-	@NotBlank(message = "상품 상태는 필수입니다.")
-	private String productStatus;
 
 	@NotNull(message = "상품 타입은 필수입니다.")
 	private ProductType productType;

--- a/src/main/java/com/limito/order/cart/domain/dto/limitedproduct/AddCartLimitedResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/limitedproduct/AddCartLimitedResponseV1.java
@@ -22,6 +22,7 @@ public class AddCartLimitedResponseV1 {
 	private String thumbnailUrl;
 	private Long sellerId;
 	private String productStatus;
+	private Boolean isSoldOut;
 	private ProductType productType;
 	private int productAmount;
 }

--- a/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellRequestV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellRequestV1.java
@@ -14,6 +14,9 @@ public class AddCartResellRequestV1 {
 	@NotNull(message = "옵션 아이디는 필수입니다.")
 	private UUID optionId;
 
+	@NotNull(message = "재고 아이디는 필수입니다.")
+	private UUID stockId;
+
 	@NotNull(message = "상품 아이디는 필수입니다.")
 	private UUID productId;
 

--- a/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellRequestV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellRequestV1.java
@@ -4,9 +4,7 @@ import java.util.UUID;
 
 import com.limito.order.common.ProductType;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,33 +14,8 @@ public class AddCartResellRequestV1 {
 	@NotNull(message = "옵션 아이디는 필수입니다.")
 	private UUID optionId;
 
-	@NotNull(message = "재고 아이디는 필수입니다.")
-	private UUID stockId;
-
 	@NotNull(message = "상품 아이디는 필수입니다.")
 	private UUID productId;
-
-	@NotBlank(message = "상품 이름은 필수입니다.")
-	private String productName;
-
-	@NotBlank(message = "상품 색상은 필수입니다.")
-	private String productColor;
-
-	@NotBlank(message = "상품 사이즈는 필수입니다.")
-	private String productSize;
-
-	@NotNull(message = "상품 가격은 필수입니다.")
-	@Positive
-	private int productPrice;
-
-	@NotBlank(message = "브랜드명은 필수입니다.")
-	private String brandName;
-
-	@NotBlank(message = "대표 이미지 url은 필수입니다.")
-	private String thumbnailUrl;
-
-	@NotNull(message = "판매자 아이디는 필수입니다.")
-	private Long sellerId;
 
 	@NotNull(message = "상품 타입은 필수입니다.")
 	private ProductType productType;

--- a/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellResponseV1.java
+++ b/src/main/java/com/limito/order/cart/domain/dto/resellproduct/AddCartResellResponseV1.java
@@ -15,12 +15,5 @@ public class AddCartResellResponseV1 {
 	private UUID optionId;
 	private UUID stockId;
 	private UUID productId;
-	private String productName;
-	private String productColor;
-	private String productSize;
-	private int productPrice;
-	private String brandName;
-	private String thumbnailUrl;
-	private Long sellerId;
 	private ProductType productType;
 }

--- a/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
+++ b/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
@@ -43,6 +43,7 @@ public class CartMapper {
 			.thumbnailUrl(domain.getThumbnailUrl())
 			.sellerId(domain.getSellerId())
 			.productStatus(domain.getProductStatus())
+			.isSoldOut(domain.getIsSoldOut())
 			.productType(domain.getProductType())
 			.productAmount(domain.getProductAmount())
 			.build();

--- a/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
+++ b/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
@@ -1,6 +1,7 @@
 package com.limito.order.cart.domain.mapper;
 
 import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.resell.OptionInfosGetResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedRequestV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.GetCartLimitedResponseV1;
@@ -69,13 +70,6 @@ public class CartMapper {
 			.optionId(req.getOptionId())
 			.stockId(req.getStockId())
 			.productId(req.getProductId())
-			.productName(req.getProductName())
-			.productColor(req.getProductColor())
-			.productSize(req.getProductSize())
-			.productPrice(req.getProductPrice())
-			.brandName(req.getBrandName())
-			.thumbnailUrl(req.getThumbnailUrl())
-			.sellerId(req.getSellerId())
 			.productType(req.getProductType())
 			.build();
 	}
@@ -85,29 +79,22 @@ public class CartMapper {
 			.optionId(domain.getOptionId())
 			.stockId(domain.getStockId())
 			.productId(domain.getProductId())
-			.productName(domain.getProductName())
-			.productColor(domain.getProductColor())
-			.productSize(domain.getProductSize())
-			.productPrice(domain.getProductPrice())
-			.brandName(domain.getBrandName())
-			.thumbnailUrl(domain.getThumbnailUrl())
-			.sellerId(domain.getSellerId())
 			.productType(domain.getProductType())
 			.build();
 	}
 
-	public static GetCartResellResponseV1 toGetResponse(ResellCacheItem domain) {
+	public static GetCartResellResponseV1 toGetResponse(ResellCacheItem domain, OptionInfosGetResponseV1 optionInfo) {
 		return GetCartResellResponseV1.builder()
 			.optionId(domain.getOptionId())
 			.stockId(domain.getStockId())
 			.productId(domain.getProductId())
-			.productName(domain.getProductName())
-			.productColor(domain.getProductColor())
-			.productSize(domain.getProductSize())
-			.productPrice(domain.getProductPrice())
-			.brandName(domain.getBrandName())
-			.thumbnailUrl(domain.getThumbnailUrl())
-			.sellerId(domain.getSellerId())
+			.productName(optionInfo.getProductName())
+			.productColor(optionInfo.getProductColor())
+			.productSize(optionInfo.getProductSize())
+			.productPrice(optionInfo.getProductPrice())
+			.brandName(optionInfo.getBrandName())
+			.thumbnailUrl(optionInfo.getThumbnailUrl())
+			.sellerId(optionInfo.getSellerId())
 			.productType(domain.getProductType())
 			.build();
 	}

--- a/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
+++ b/src/main/java/com/limito/order/cart/domain/mapper/CartMapper.java
@@ -1,5 +1,6 @@
 package com.limito.order.cart.domain.mapper;
 
+import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedRequestV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.GetCartLimitedResponseV1;
@@ -11,18 +12,19 @@ import com.limito.order.cart.domain.model.ResellCacheItem;
 
 public class CartMapper {
 
-	public static LimitedCacheItem toDomain(AddCartLimitedRequestV1 req) {
+	public static LimitedCacheItem toDomain(AddCartLimitedRequestV1 req, GetInCartProductInfoResponseV1 productInfo) {
 		return LimitedCacheItem.builder()
 			.optionId(req.getOptionId())
 			.productItemId(req.getProductItemId())
-			.productName(req.getProductName())
-			.productColor(req.getProductColor())
-			.productSize(req.getProductSize())
-			.productPrice(req.getProductPrice())
-			.brandName(req.getBrandName())
-			.thumbnailUrl(req.getThumbnailUrl())
-			.sellerId(req.getSellerId())
-			.productStatus(req.getProductStatus())
+			.productName(productInfo.getProductName())
+			.productColor(productInfo.getProductColor())
+			.productSize(productInfo.getProductSize())
+			.productPrice(productInfo.getProductPrice())
+			.brandName(productInfo.getBrandName())
+			.thumbnailUrl(productInfo.getThumbnailUrl())
+			.sellerId(productInfo.getSellerId())
+			.productStatus(productInfo.getProductStatus())
+			.isSoldOut(productInfo.getIsSoldOut())
 			.productType(req.getProductType())
 			.productAmount(req.getProductAmount())
 			.build();

--- a/src/main/java/com/limito/order/cart/domain/model/LimitedCacheItem.java
+++ b/src/main/java/com/limito/order/cart/domain/model/LimitedCacheItem.java
@@ -26,6 +26,7 @@ public class LimitedCacheItem {
 	private String thumbnailUrl;
 	private Long sellerId;
 	private String productStatus;
+	private Boolean isSoldOut;
 	private ProductType productType;
 	private int productAmount;
 }

--- a/src/main/java/com/limito/order/cart/domain/model/ResellCacheItem.java
+++ b/src/main/java/com/limito/order/cart/domain/model/ResellCacheItem.java
@@ -17,14 +17,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ResellCacheItem {
 	private UUID optionId;
-	private UUID stockId;
 	private UUID productId;
-	private String productName;
-	private String productColor;
-	private String productSize;
-	private int productPrice;
-	private String brandName;
-	private String thumbnailUrl;
-	private Long sellerId;
 	private ProductType productType;
 }

--- a/src/main/java/com/limito/order/cart/domain/model/ResellCacheItem.java
+++ b/src/main/java/com/limito/order/cart/domain/model/ResellCacheItem.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ResellCacheItem {
 	private UUID optionId;
+	private UUID stockId;
 	private UUID productId;
 	private ProductType productType;
 }

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -1,9 +1,12 @@
 package com.limito.order.cart.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,6 +18,7 @@ import com.limito.common.exception.AppException;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitRequestV1;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.resell.OptionInfosGetResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedRequestV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.GetCartLimitedResponseV1;
@@ -25,6 +29,7 @@ import com.limito.order.cart.domain.mapper.CartMapper;
 import com.limito.order.cart.domain.model.LimitedCacheItem;
 import com.limito.order.cart.domain.model.ResellCacheItem;
 import com.limito.order.common.feignclient.LimitedFeignClient;
+import com.limito.order.common.feignclient.ResellFeignClient;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +43,7 @@ public class CartServiceV1 {
 
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final LimitedFeignClient limitedFeignClient;
+	private final ResellFeignClient resellFeignClient;
 
 	private HashOperations<String, String, Object> hashOps() {
 		return redisTemplate.opsForHash();
@@ -152,13 +158,41 @@ public class CartServiceV1 {
 
 		// HGETALL cart:resell:{userId}
 		Map<String, Object> entries = hashOps.entries(key);
-
-		// 값(value)만 꺼내서 LimitedCacheItem → 응답 DTO로 변환
-		return entries.values().stream()
-			.map(value -> (ResellCacheItem)value)
-			.map(CartMapper::toGetResponse)
+		List<UUID> optionIds = entries.keySet().stream()
+			.map(UUID::fromString)
 			.toList();
 
+		// 리셀 feign client 요청 - 상품 정보
+		ResponseEntity<List<OptionInfosGetResponseV1>> productInfoRes = resellFeignClient.getOptionInfos(optionIds);
+		List<OptionInfosGetResponseV1> productInfos = productInfoRes.getBody();
+		if (productInfos == null) {
+			throw AppException.of(HttpStatus.EXPECTATION_FAILED, "리셀 상품 정보 요청에 실패했습니다.");
+		}
+
+		// 상품 정보  응답 optionId -> 정보 맵으로 변환
+		Map<UUID, OptionInfosGetResponseV1> optionInfoMap = productInfos.stream()
+			.collect(Collectors.toMap(
+				OptionInfosGetResponseV1::getOptionId,
+				info -> info
+			));
+
+		// 아이디 집합 검증 (양쪽이 정확히 같은지)
+		Set<UUID> requestIdSet = new HashSet<>(optionIds);
+		Set<UUID> responseIdSet = optionInfoMap.keySet();
+		if (!requestIdSet.equals(responseIdSet)) {
+			log.error("리셀 상품 정보 요청의 결과가 올바르지 않습니다. requestIds={}, responseIds={}",
+				requestIdSet, responseIdSet);
+			throw AppException.of(HttpStatus.NOT_ACCEPTABLE, "리셀 상품 정보 요청의 결과가 올바르지 않습니다.");
+		}
+
+		return entries.values().stream()
+			.map(value -> (ResellCacheItem)value)
+			.map(cacheItem -> {
+				UUID optionId = cacheItem.getOptionId();
+				OptionInfosGetResponseV1 optionInfo = optionInfoMap.get(optionId);
+				return CartMapper.toGetResponse(cacheItem, optionInfo);
+			})
+			.toList();
 	}
 
 	// 주문 완료된 한정판매 상품 장바구니 삭제
@@ -246,5 +280,9 @@ public class CartServiceV1 {
 			throw AppException.of(HttpStatus.BAD_REQUEST,
 				"최대 구매 가능한 수량을 초과하였습니다. 최대 구매 가능 수량 : " + purchaseAmountLimitCnt + "개");
 		}
+	}
+
+	public ResellFeignClient getResellFeignClient() {
+		return resellFeignClient;
 	}
 }

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -12,8 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.limito.common.exception.AppException;
-import com.limito.order.cart.domain.dto.feignclient.GetPurchaseAmountLimitRequestV1;
-import com.limito.order.cart.domain.dto.feignclient.GetPurchaseAmountLimitResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitRequestV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedRequestV1;
 import com.limito.order.cart.domain.dto.limitedproduct.AddCartLimitedResponseV1;
 import com.limito.order.cart.domain.dto.limitedproduct.GetCartLimitedResponseV1;
@@ -32,13 +33,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CartServiceV1 {
-
-	private final LimitedFeignClient limitedFeignClient;
-
 	private static final String LIMITED_KEY = "cart:limited:%d";
 	private static final String RESELL_KEY = "cart:resell:%d";
 
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final LimitedFeignClient limitedFeignClient;
 
 	private HashOperations<String, String, Object> hashOps() {
 		return redisTemplate.opsForHash();
@@ -61,8 +60,6 @@ public class CartServiceV1 {
 		HashOperations<String, String, Object> hashOps = hashOps();
 		LimitedCacheItem existing = (LimitedCacheItem)hashOps.get(key, field);
 
-		LimitedCacheItem cacheItem = CartMapper.toDomain(addLimitedProductReqDto);
-
 		// 한정판매 feign client 요청 - 최대 구매 가능 수량
 		ResponseEntity<GetPurchaseAmountLimitResponseV1> feignRes = getFeignResponse(addLimitedProductReqDto);
 
@@ -72,6 +69,18 @@ public class CartServiceV1 {
 		int purchaseAmountLimitCnt = purchaseAmountLimit.getPurchaseAmountLimit();
 		log.info("최대 구매 가능 수량 : {}", purchaseAmountLimitCnt);
 
+		// 한정판매 feign client 요청 - 상품 정보
+		ResponseEntity<GetInCartProductInfoResponseV1> productInfoRes = limitedFeignClient.getInCartProductInfo(
+			limitedProductItemId);
+		GetInCartProductInfoResponseV1 productInfo = productInfoRes.getBody();
+		if (productInfo == null) {
+			throw AppException.of(HttpStatus.EXPECTATION_FAILED, "상품 정보 요청에 실패했습니다");
+		}
+
+		if (productInfo.getIsSoldOut()) {
+			throw AppException.of(HttpStatus.BAD_REQUEST, "픔절된 상품은 장바구니에 추가할 수 없습니다.");
+		}
+		LimitedCacheItem cacheItem = CartMapper.toDomain(addLimitedProductReqDto, productInfo);
 		// 수량 추가
 		if (existing != null) {
 			cacheItem = validateIncreaseAmount(existing, addLimitedProductReqDto, purchaseAmountLimitCnt);
@@ -224,8 +233,12 @@ public class CartServiceV1 {
 		return existing;
 	}
 
-	private void canAddNewProduct(AddCartLimitedRequestV1 addLimitedProductReqDto, LimitedCacheItem cacheItem,
-		UUID limitedProductItemId, int purchaseAmountLimitCnt) {
+	private void canAddNewProduct(
+		AddCartLimitedRequestV1 addLimitedProductReqDto,
+		LimitedCacheItem cacheItem,
+		UUID limitedProductItemId,
+		int purchaseAmountLimitCnt
+	) {
 		boolean canAdd = limitedProductItemId.equals(addLimitedProductReqDto.getProductItemId())
 			&& cacheItem.getProductAmount() <= purchaseAmountLimitCnt; // 여기서 merged 총량 기준으로 보는 것도 가능
 

--- a/src/main/java/com/limito/order/cart/service/CartServiceV1.java
+++ b/src/main/java/com/limito/order/cart/service/CartServiceV1.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.limito.common.exception.AppException;
+import com.limito.common.security.context.UserContext;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitRequestV1;
 import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitResponseV1;
@@ -57,7 +58,8 @@ public class CartServiceV1 {
 	 * 3. 장바구니 추가
 	 * 4. 반환
 	 */
-	public AddCartLimitedResponseV1 addLimitedItem(Long userId, AddCartLimitedRequestV1 addLimitedProductReqDto) {
+	public AddCartLimitedResponseV1 addLimitedItem(UserContext user, AddCartLimitedRequestV1 addLimitedProductReqDto) {
+		Long userId = user.getUserId();
 		String key = LIMITED_KEY.formatted(userId);
 		// 필드 : 한정판매는 판매 아이템 아이디, 리셀은 옵션아이디
 		String field = addLimitedProductReqDto.getProductItemId().toString();
@@ -109,8 +111,8 @@ public class CartServiceV1 {
 	}
 
 	// 리셀 장바구니 추가
-	public AddCartResellResponseV1 addResellItem(Long userId, AddCartResellRequestV1 addResellProductReqDto) {
-
+	public AddCartResellResponseV1 addResellItem(UserContext user, AddCartResellRequestV1 addResellProductReqDto) {
+		Long userId = user.getUserId();
 		String key = RESELL_KEY.formatted(userId);
 		String field = addResellProductReqDto.getOptionId().toString();
 
@@ -136,7 +138,8 @@ public class CartServiceV1 {
 	}
 
 	// 한정판매 장바구니 조회
-	public List<GetCartLimitedResponseV1> getLimitedCart(Long userId) {
+	public List<GetCartLimitedResponseV1> getLimitedCart(UserContext user) {
+		Long userId = user.getUserId();
 		String key = LIMITED_KEY.formatted(userId);
 		HashOperations<String, String, Object> hashOps = hashOps();
 
@@ -152,7 +155,8 @@ public class CartServiceV1 {
 	}
 
 	// 리셀 장바구니 조회
-	public List<GetCartResellResponseV1> getResellCart(Long userId) {
+	public List<GetCartResellResponseV1> getResellCart(UserContext user) {
+		Long userId = user.getUserId();
 		String key = RESELL_KEY.formatted(userId);
 		HashOperations<String, String, Object> hashOps = hashOps();
 
@@ -196,21 +200,23 @@ public class CartServiceV1 {
 	}
 
 	// 주문 완료된 한정판매 상품 장바구니 삭제
-	public void deleteLimitedOrderItem(Long userId, List<UUID> productItemIds) {
+	public void deleteLimitedOrderItem(UserContext user, List<UUID> productItemIds) {
 		if (productItemIds == null || productItemIds.isEmpty()) {
 			throw AppException.of(HttpStatus.NO_CONTENT, "장바구니에서 삭제할 상품 아이디가 존재하지 않습니다.");
 		}
 
+		Long userId = user.getUserId();
 		String key = LIMITED_KEY.formatted(userId);
 		deleteOrderItems(key, productItemIds);
 	}
 
 	// 주문 완료된 리셀 상품 장바구니 삭제
-	public void deleteResellOrderItem(Long userId, List<UUID> optionIds) {
+	public void deleteResellOrderItem(UserContext user, List<UUID> optionIds) {
 		if (optionIds == null || optionIds.isEmpty()) {
 			throw AppException.of(HttpStatus.NO_CONTENT, "장바구니에서 삭제할 상품 아이디가 존재하지 않습니다.");
 		}
 
+		Long userId = user.getUserId();
 		String key = RESELL_KEY.formatted(userId);
 		deleteOrderItems(key, optionIds);
 	}
@@ -280,9 +286,5 @@ public class CartServiceV1 {
 			throw AppException.of(HttpStatus.BAD_REQUEST,
 				"최대 구매 가능한 수량을 초과하였습니다. 최대 구매 가능 수량 : " + purchaseAmountLimitCnt + "개");
 		}
-	}
-
-	public ResellFeignClient getResellFeignClient() {
-		return resellFeignClient;
 	}
 }

--- a/src/main/java/com/limito/order/common/feignclient/LimitedFeignClient.java
+++ b/src/main/java/com/limito/order/common/feignclient/LimitedFeignClient.java
@@ -1,12 +1,17 @@
 package com.limito.order.common.feignclient;
 
+import java.util.UUID;
+
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import com.limito.order.cart.domain.dto.feignclient.GetPurchaseAmountLimitRequestV1;
-import com.limito.order.cart.domain.dto.feignclient.GetPurchaseAmountLimitResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetInCartProductInfoResponseV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitRequestV1;
+import com.limito.order.cart.domain.dto.feignclient.limited.GetPurchaseAmountLimitResponseV1;
 import com.limito.order.order.domain.dto.feignclient.limited.CancelReserveStockRequestV1;
 import com.limito.order.order.domain.dto.feignclient.limited.GetOrderedProductInfoRequestV1;
 import com.limito.order.order.domain.dto.feignclient.limited.GetOrderedProductInfoResponseV1;
@@ -15,6 +20,7 @@ import com.limito.order.order.domain.dto.feignclient.limited.ReserveStockRequest
 import com.limito.order.order.domain.dto.feignclient.limited.RollbackStockRequestV1;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 @FeignClient(name = "limited-product-service", url = "${feign.limited-product-service.url}")
 public interface LimitedFeignClient {
@@ -23,6 +29,13 @@ public interface LimitedFeignClient {
 	@PostMapping("/internal/v1/limited-products/purchase-amount-limit")
 	ResponseEntity<GetPurchaseAmountLimitResponseV1> getPurchaseAmountLimits(
 		@Valid @RequestBody GetPurchaseAmountLimitRequestV1 request
+	);
+
+	// 장바구니 추가 상품 정보
+	@GetMapping("/in-cart-product/{limitedProductItemId}")
+	public ResponseEntity<GetInCartProductInfoResponseV1> getInCartProductInfo(
+		@NotNull(message = "아이템 id는 null일 수 없습니다.")
+		@PathVariable UUID limitedProductItemId
 	);
 
 	// 임시 재고 예약

--- a/src/main/java/com/limito/order/common/feignclient/LimitedFeignClient.java
+++ b/src/main/java/com/limito/order/common/feignclient/LimitedFeignClient.java
@@ -32,7 +32,7 @@ public interface LimitedFeignClient {
 	);
 
 	// 장바구니 추가 상품 정보
-	@GetMapping("/in-cart-product/{limitedProductItemId}")
+	@GetMapping("/internal/v1/limited-products/in-cart-product/{limitedProductItemId}")
 	public ResponseEntity<GetInCartProductInfoResponseV1> getInCartProductInfo(
 		@NotNull(message = "아이템 id는 null일 수 없습니다.")
 		@PathVariable UUID limitedProductItemId

--- a/src/main/java/com/limito/order/common/feignclient/ResellFeignClient.java
+++ b/src/main/java/com/limito/order/common/feignclient/ResellFeignClient.java
@@ -21,7 +21,7 @@ import jakarta.validation.Valid;
 @FeignClient(name = "resell-product-service", url = "${feign.resell-product-service.url}")
 public interface ResellFeignClient {
 	// 장바구니 추가 상품 정뵤
-	@GetMapping("/optionInfo")
+	@GetMapping("/internal/v1/resell-products/optionInfo")
 	ResponseEntity<List<OptionInfosGetResponseV1>> getOptionInfos(@Valid @RequestParam List<UUID> optionIds);
 
 	// 임시 재고 예약

--- a/src/main/java/com/limito/order/common/feignclient/ResellFeignClient.java
+++ b/src/main/java/com/limito/order/common/feignclient/ResellFeignClient.java
@@ -5,9 +5,12 @@ import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import com.limito.order.cart.domain.dto.feignclient.resell.OptionInfosGetResponseV1;
 import com.limito.order.order.domain.dto.feignclient.resell.request.ProductInfosGetRequestV1;
 import com.limito.order.order.domain.dto.feignclient.resell.request.StockReduceRequest;
 import com.limito.order.order.domain.dto.feignclient.resell.request.StockRollbackRequest;
@@ -17,6 +20,10 @@ import jakarta.validation.Valid;
 
 @FeignClient(name = "resell-product-service", url = "${feign.resell-product-service.url}")
 public interface ResellFeignClient {
+	// 장바구니 추가 상품 정뵤
+	@GetMapping("/optionInfo")
+	ResponseEntity<List<OptionInfosGetResponseV1>> getOptionInfos(@Valid @RequestParam List<UUID> optionIds);
+
 	// 임시 재고 예약
 	@PostMapping("/internal/v1/resell-products/stock/reserve")
 	ResponseEntity<Void> reserveStock(@RequestBody List<UUID> stockIds);
@@ -27,15 +34,15 @@ public interface ResellFeignClient {
 
 	// 임시 재고 예약 취소
 	@PostMapping("/internal/v1/resell-products/stock/cancel")
-	public ResponseEntity<Void> cancelStock(@RequestBody List<UUID> stockIds);
+	ResponseEntity<Void> cancelStock(@RequestBody List<UUID> stockIds);
 
 	// 재고 복원
 	@PostMapping("/internal/v1/resell-products/stock/rollback")
-	public ResponseEntity<Void> rollbackStock(@Valid @RequestBody List<StockRollbackRequest> request);
+	ResponseEntity<Void> rollbackStock(@Valid @RequestBody List<StockRollbackRequest> request);
 
 	// 주문 상품 정보 요청
 	@PostMapping("/internal/v1/resell-products/productInfo")
-	public ResponseEntity<List<ProductInfosGetResponseV1>> getProductInfos(
+	ResponseEntity<List<ProductInfosGetResponseV1>> getProductInfos(
 		@RequestBody List<ProductInfosGetRequestV1> request
 	);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,9 +10,9 @@ spring:
       port: 6379
       database: 0
   datasource:
-    url: jdbc:postgresql://localhost:5432/limito-db
-    username: postgres
-    password: postgres
+    url: ${DB_USER:jdbc:postgresql://localhost:5432/limito-db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
#60 

### 변경사항
- [ ] 한정판매
    - [ ] 장바구니 추가 요청 시 requestDto로 아이디, 수량, 상품 타입만 들어옴
    - [ ] 위 데이터 중 아이템 아이디로 한정판매 서비스에 feign 요청 -> 상품 정보 응답
    - [ ] requestDto + 상품 정보 합쳐서 캐싱
    - [ ] 조회 시 캐싱된 데이터 반환

- [ ] 리셀
    - [ ] 장바구니 추가 요청 시 requestDto로 아이디, 상품 타입만 들어옴 
    - [ ] 위 requestDto의 데이터만 캐싱
    - [ ] 매 조회 시 캐싱 데이터 중 옵션 아이디 리스트로 리셀 서비스에 feign 요청 -> 캐싱 데이터와 합쳐서 반환


### 리뷰 요청
- [ ] 변경이 잘 이루어 졌는지
- [ ] 그 외의 질문이나 수정사항은 리뷰 남겨주세요